### PR TITLE
Allow Exchange account for Office 365

### DIFF
--- a/ispdb/hotmail.com
+++ b/ispdb/hotmail.com
@@ -20,6 +20,15 @@
     <domain>outlook.com</domain>
     <displayName>Outlook.com (Microsoft)</displayName>
     <displayShortName>Outlook</displayShortName>
+    <incomingServer type="exchange">
+      <hostname>outlook.office365.com</hostname>
+      <port>443</port>
+      <username>%EMAILADDRESS%</username>
+      <socketType>SSL</socketType>
+      <authentication>OAuth2</authentication>
+      <owaURL>https://outlook.office365.com/owa/</owaURL>
+      <ewsURL>https://outlook.office365.com/ews/exchange.asmx</ewsURL>
+    </incomingServer>
     <incomingServer type="imap">
       <hostname>outlook.office365.com</hostname>
       <port>993</port>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1571772

Older clients will ignore this change, but newer clients will offer Exchange as an alternative.