### PR TITLE
Disable SMTP server when creating OWL account

### DIFF
--- a/ispdb/hotmail.com
+++ b/ispdb/hotmail.com
@@ -28,6 +28,7 @@
       <authentication>OAuth2</authentication>
       <owaURL>https://outlook.office365.com/owa/</owaURL>
       <ewsURL>https://outlook.office365.com/ews/exchange.asmx</ewsURL>
+      <useGlobalPreferredServer>true</useGlobalPreferredServer>
     </incomingServer>
     <incomingServer type="imap">
       <hostname>outlook.office365.com</hostname>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1583777

Older clients will ignore this change, but newer clients will skip the creation of the SMTP server.