### PR TITLE
Move exhange type accounts last on the incoming server list

### DIFF
--- a/ispdb/office365.com
+++ b/ispdb/office365.com
@@ -8,16 +8,6 @@
     <domain>mail.protection.outlook.com</domain>
     <displayName>Office365 (Microsoft)</displayName>
     <displayShortName>Office365</displayShortName>
-    <incomingServer type="exchange">
-      <hostname>outlook.office365.com</hostname>
-      <port>443</port>
-      <username>%EMAILADDRESS%</username>
-      <socketType>SSL</socketType>
-      <authentication>OAuth2</authentication>
-      <owaURL>https://outlook.office365.com/owa/</owaURL>
-      <ewsURL>https://outlook.office365.com/ews/exchange.asmx</ewsURL>
-      <useGlobalPreferredServer>true</useGlobalPreferredServer>
-    </incomingServer>
     <incomingServer type="imap">
       <hostname>outlook.office365.com</hostname>
       <port>993</port>
@@ -34,6 +24,16 @@
       <pop3>
         <leaveMessagesOnServer>true</leaveMessagesOnServer>
       </pop3>
+    </incomingServer>
+    <incomingServer type="exchange">
+      <hostname>outlook.office365.com</hostname>
+      <port>443</port>
+      <username>%EMAILADDRESS%</username>
+      <socketType>SSL</socketType>
+      <authentication>OAuth2</authentication>
+      <owaURL>https://outlook.office365.com/owa/</owaURL>
+      <ewsURL>https://outlook.office365.com/ews/exchange.asmx</ewsURL>
+      <useGlobalPreferredServer>true</useGlobalPreferredServer>
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.office365.com</hostname>

--- a/ispdb/outlook.com
+++ b/ispdb/outlook.com
@@ -15,16 +15,6 @@
     <domain>outlook.com</domain>
     <displayName>Microsoft</displayName>
     <displayShortName>Microsoft</displayShortName>
-    <incomingServer type="exchange">
-      <hostname>outlook.office365.com</hostname>
-      <port>443</port>
-      <username>%EMAILADDRESS%</username>
-      <socketType>SSL</socketType>
-      <authentication>OAuth2</authentication>
-      <owaURL>https://outlook.office365.com/owa/</owaURL>
-      <ewsURL>https://outlook.office365.com/ews/exchange.asmx</ewsURL>
-      <useGlobalPreferredServer>true</useGlobalPreferredServer>
-    </incomingServer>
     <incomingServer type="imap">
       <hostname>outlook.office365.com</hostname>
       <port>993</port>
@@ -42,6 +32,16 @@
         <leaveMessagesOnServer>true</leaveMessagesOnServer>
         <!-- Outlook.com docs specifically mention that POP3 deletes have effect on the main inbox on webmail and IMAP -->
       </pop3>
+    </incomingServer>
+    <incomingServer type="exchange">
+      <hostname>outlook.office365.com</hostname>
+      <port>443</port>
+      <username>%EMAILADDRESS%</username>
+      <socketType>SSL</socketType>
+      <authentication>OAuth2</authentication>
+      <owaURL>https://outlook.office365.com/owa/</owaURL>
+      <ewsURL>https://outlook.office365.com/ews/exchange.asmx</ewsURL>
+      <useGlobalPreferredServer>true</useGlobalPreferredServer>
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.office365.com</hostname>


### PR DESCRIPTION
Move exhange type accounts last on the incoming server list, so exchange doesn't inadvertently get set as default.

Fixes the "default" part of https://bugzilla.mozilla.org/show_bug.cgi?id=1592258
