### PR TITLE
Update aol.com to include netscape.com, compuserve.com and cs.com as they are currently defaulting to yahoo provider

### DIFF
--- a/ispdb/aol.com
+++ b/ispdb/aol.com
@@ -3,6 +3,10 @@
     <domain>aol.com</domain>
     <domain>aim.com</domain>
     <domain>netscape.net</domain>
+    <domain>netscape.com</domain>
+    <domain>compuserve.com</domain>
+    <domain>cs.com</domain>
+    <domain>wmconnect.com</domain>
     <displayName>AOL Mail</displayName>
     <displayShortName>AOL</displayShortName>
     <incomingServer type="imap">


### PR DESCRIPTION
@benbucksch or @jorgk3  , Can you review this PR? This is breaking a few AOL domains on Thunderbird.