### PR TITLE
Add OAuth2 parameters to the ISPs that use OAuth2 #18

### DIFF
--- a/ispdb/aol.com
+++ b/ispdb/aol.com
@@ -1,12 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <clientConfig version="1.1">
   <emailProvider id="aol.com">
     <domain>aol.com</domain>
+    <!-- Brands -->
     <domain>aim.com</domain>
     <domain>netscape.net</domain>
     <domain>netscape.com</domain>
     <domain>compuserve.com</domain>
     <domain>cs.com</domain>
     <domain>wmconnect.com</domain>
+    <!-- Country domains -->
     <domain>aol.de</domain>
     <domain>aol.it</domain>
     <domain>aol.fr</domain>
@@ -20,8 +23,10 @@
     <domain>aol.com.mx</domain>
     <!-- MX -->
     <domain>mail.gm0.yahoodns.net</domain>
+
     <displayName>AOL Mail</displayName>
     <displayShortName>AOL</displayShortName>
+
     <incomingServer type="imap">
       <hostname>imap.aol.com</hostname>
       <port>993</port>
@@ -46,10 +51,19 @@
       <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </outgoingServer>
+
     <documentation url="https://help.aol.com/articles/how-do-i-use-other-email-applications-to-send-and-receive-my-aol-mail">
       <descr lang="en">How do I set up other email applications to send and receive my AOL Mail?</descr>
     </documentation>
   </emailProvider>
+
+  <oAuth2>
+    <issuer>login.aol.com</issuer>
+    <scope>mail-w</scope>
+    <authURL>https://api.login.aol.com/oauth2/request_auth</authURL>
+    <tokenURL>https://api.login.aol.com/oauth2/get_token</tokenURL>
+  </oAuth2>
+
   <webMail>
     <loginPage url="https://mail.aol.com/"/>
     <loginPageInfo url="https://mail.aol.com/">

--- a/ispdb/googlemail.com
+++ b/ispdb/googlemail.com
@@ -7,8 +7,10 @@
     <domain>google.com</domain>
     <!-- HACK. Only add ISPs with 100000+ users here -->
     <domain>jazztel.es</domain>
+
     <displayName>Google Mail</displayName>
     <displayShortName>GMail</displayShortName>
+
     <incomingServer type="imap">
       <hostname>imap.gmail.com</hostname>
       <port>993</port>
@@ -22,6 +24,7 @@
       <port>995</port>
       <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
       <pop3>
         <leaveMessagesOnServer>true</leaveMessagesOnServer>
@@ -35,9 +38,7 @@
       <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <enable visiturl="https://mail.google.com/mail/?ui=2&amp;shva=1#settings/fwdandpop">
-      <instruction>You need to enable IMAP access</instruction>
-    </enable>
+
     <documentation url="http://mail.google.com/support/bin/answer.py?answer=13273">
       <descr>How to enable IMAP/POP3 in GMail</descr>
     </documentation>
@@ -51,6 +52,18 @@
       <descr>How to configure TB 2.0 for POP3</descr>
     </documentation>
   </emailProvider>
+
+  <oAuth2>
+    <issuer>accounts.google.com</issuer>
+    <!-- https://developers.google.com/identity/protocols/oauth2/scopes -->
+    <scope>https://mail.google.com/ https://www.googleapis.com/auth/contacts https://www.googleapis.com/auth/carddav</scope>
+    <authURL>https://accounts.google.com/o/oauth2/auth</authURL>
+    <tokenURL>https://www.googleapis.com/oauth2/v3/token</tokenURL>
+  </oAuth2>
+
+  <enable visiturl="https://mail.google.com/mail/?ui=2&amp;shva=1#settings/fwdandpop">
+    <instruction>You need to enable IMAP access</instruction>
+  </enable>
 
   <webMail>
     <loginPage url="https://accounts.google.com/ServiceLogin?service=mail&amp;continue=http://mail.google.com/mail/" />

--- a/ispdb/googlemail.com
+++ b/ispdb/googlemail.com
@@ -56,7 +56,7 @@
   <oAuth2>
     <issuer>accounts.google.com</issuer>
     <!-- https://developers.google.com/identity/protocols/oauth2/scopes -->
-    <scope>https://mail.google.com/ https://www.googleapis.com/auth/contacts https://www.googleapis.com/auth/carddav</scope>
+    <scope>https://mail.google.com/ https://www.googleapis.com/auth/contacts https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/carddav</scope>
     <authURL>https://accounts.google.com/o/oauth2/auth</authURL>
     <tokenURL>https://www.googleapis.com/oauth2/v3/token</tokenURL>
   </oAuth2>

--- a/ispdb/mail.ru
+++ b/ispdb/mail.ru
@@ -6,8 +6,10 @@
     <domain>list.ru</domain>
     <domain>bk.ru</domain>
     <domain>corp.mail.ru</domain>
+
     <displayName>mail.ru</displayName>
     <displayShortName>mail.ru</displayShortName>
+
     <incomingServer type="imap">
       <hostname>imap.mail.ru</hostname>
       <port>993</port>
@@ -54,8 +56,17 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+
+    <documentation url="http://help.mail.ru/mail-help/mailer/mt">
+      <descr lang="en">IMAP, POP, Thunderbird, with screenshots</descr>
+    </documentation>
   </emailProvider>
-  <documentation url="http://help.mail.ru/mail-help/mailer/mt">
-    <descr lang="en">IMAP, POP, Thunderbird, with screenshots</descr>
-  </documentation>
+
+  <oAuth2>
+    <issuer>o2.mail.ru</issuer>
+    <scope>mail.imap</scope>
+    <authURL>https://o2.mail.ru/login</authURL>
+    <tokenURL>https://o2.mail.ru/token</tokenURL>
+  </oAuth2>
+
 </clientConfig>

--- a/ispdb/office365.com
+++ b/ispdb/office365.com
@@ -6,8 +6,10 @@
     <domain>onmicrosoft.com</domain>
     <!-- MX e.g. example.mail.protection.outlook.com -->
     <domain>mail.protection.outlook.com</domain>
+
     <displayName>Office365 (Microsoft)</displayName>
     <displayShortName>Office365</displayShortName>
+
     <incomingServer type="imap">
       <hostname>outlook.office365.com</hostname>
       <port>993</port>
@@ -43,4 +45,12 @@
       <username>%EMAILADDRESS%</username>
     </outgoingServer>
   </emailProvider>
+
+  <oAuth2>
+    <issuer>login.microsoftonline.com</issuer>
+    <scope>https://outlook.office365.com/IMAP.AccessAsUser.All https://outlook.office365.com/POP.AccessAsUser.All https://outlook.office365.com/SMTP.Send offline_access</scope>
+    <authURL>https://login.microsoftonline.com/common/oauth2/v2.0/authorize</authURL>
+    <tokenURL>https://login.microsoftonline.com/common/oauth2/v2.0/token</tokenURL>
+  </oAuth2>
+
 </clientConfig>

--- a/ispdb/office365.com
+++ b/ispdb/office365.com
@@ -49,6 +49,7 @@
   <oAuth2>
     <issuer>login.microsoftonline.com</issuer>
     <scope>https://outlook.office365.com/IMAP.AccessAsUser.All https://outlook.office365.com/POP.AccessAsUser.All https://outlook.office365.com/SMTP.Send offline_access</scope>
+    <!-- https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints -->
     <authURL>https://login.microsoftonline.com/common/oauth2/v2.0/authorize</authURL>
     <tokenURL>https://login.microsoftonline.com/common/oauth2/v2.0/token</tokenURL>
   </oAuth2>

--- a/ispdb/yahoo.com
+++ b/ispdb/yahoo.com
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <clientConfig version="1.1">
   <emailProvider id="yahoo.com">
     <domain>yahoo.com</domain>
@@ -19,8 +20,10 @@
     <domain>am0.yahoodns.net</domain>
     <!-- Unfortunately, also used for AOL :-( -->
     <domain>yahoodns.net</domain>
+
     <displayName>Yahoo! Mail</displayName>
     <displayShortName>Yahoo</displayShortName>
+
     <incomingServer type="imap">
       <hostname>imap.mail.yahoo.com</hostname>
       <port>993</port>
@@ -45,6 +48,7 @@
       <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+
     <documentation url="https://help.yahoo.com/kb/new-mail-for-desktop/imap-server-settings-yahoo-mail-sln4075.html">
       <descr lang="en">How to setup email applications with imap to receive Yahoo! mail?</descr>
     </documentation>
@@ -52,6 +56,14 @@
       <descr lang="en">How to setup email applications with pop to receive Yahoo! mail?</descr>
     </documentation>
   </emailProvider>
+
+  <oAuth2>
+    <issuer>login.yahoo.com</issuer>
+    <scope>mail-w</scope>
+    <authURL>https://api.login.yahoo.com/oauth2/request_auth</authURL>
+    <tokenURL>https://api.login.yahoo.com/oauth2/get_token</tokenURL>
+  </oAuth2>
+
   <webMail>
     <loginPage url="https://mail.yahoo.com" />
     <loginPageInfo url="https://mail.yahoo.com/">

--- a/ispdb/yandex.ru
+++ b/ispdb/yandex.ru
@@ -9,8 +9,10 @@
     <domain>yandex.ua</domain>
     <domain>ya.ru</domain>
     <domain>narod.ru</domain>
+
     <displayName>Yandex Mail</displayName>
     <displayShortName>Yandex</displayShortName>
+
     <incomingServer type="imap">
       <hostname>imap.yandex.com</hostname>
       <port>993</port>
@@ -32,8 +34,16 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <enable visiturl="http://mail.yandex.ru/neo/setup_client">
-      <instruction>Check 'Enable IMAP' on Yandex.Mail setup page</instruction>
-    </enable>
   </emailProvider>
+
+  <oAuth2>
+    <issuer>oauth.yandex.com</issuer>
+    <scope>mail:imap_full mail:smtp</scope>
+    <authURL>https://oauth.yandex.com/authorize</authURL>
+    <tokenURL>https://oauth.yandex.com/token</tokenURL>
+  </oAuth2>
+
+  <enable visiturl="http://mail.yandex.ru/neo/setup_client">
+    <instruction>Check 'Enable IMAP' on Yandex.Mail setup page</instruction>
+  </enable>
 </clientConfig>


### PR DESCRIPTION
OAuth2 doesn't work unless the client knows certain OAuth2 parameters. Add them to the configs of those ISPs that use OAuth2.

Does not include the client key.