### PR TITLE
Add AOL country domains and MX

### DIFF
--- a/ispdb/aol.com
+++ b/ispdb/aol.com
@@ -7,6 +7,19 @@
     <domain>compuserve.com</domain>
     <domain>cs.com</domain>
     <domain>wmconnect.com</domain>
+    <domain>aol.de</domain>
+    <domain>aol.it</domain>
+    <domain>aol.fr</domain>
+    <domain>aol.es</domain>
+    <domain>aol.se</domain>
+    <domain>aol.co.uk</domain>
+    <domain>aol.co.nz</domain>
+    <domain>aol.com.au</domain>
+    <domain>aol.com.ar</domain>
+    <domain>aol.com.br</domain>
+    <domain>aol.com.mx</domain>
+    <!-- MX -->
+    <domain>mx-aol.mail.gm0.yahoodns.net</domain>
     <displayName>AOL Mail</displayName>
     <displayShortName>AOL</displayShortName>
     <incomingServer type="imap">

--- a/ispdb/yahoo.com
+++ b/ispdb/yahoo.com
@@ -19,6 +19,7 @@
     <domain>mta5.am0.yahoodns.net</domain>
     <domain>mta6.am0.yahoodns.net</domain>
     <domain>mta7.am0.yahoodns.net</domain>
+    <!-- Thunderbird does not look up every domain level for MX, only second-level domains for MX and complete MX hostnames. -->
     <!-- Unfortunately, also used for AOL :-( -->
     <domain>yahoodns.net</domain>
     <displayName>Yahoo! Mail</displayName>

--- a/ispdb/yahoo.com
+++ b/ispdb/yahoo.com
@@ -14,6 +14,12 @@
     <domain>yahoo.com.mx</domain>
     <domain>ymail.com</domain>
     <domain>rocketmail.com</domain>
+    <!-- MX -->
+    <domain>mx-eu.mail.am0.yahoodns.net</domain>
+    <domain>mta5.am0.yahoodns.net</domain>
+    <domain>mta6.am0.yahoodns.net</domain>
+    <domain>mta7.am0.yahoodns.net</domain>
+    <!-- Unfortunately, also used for AOL :-( -->
     <domain>yahoodns.net</domain>
     <displayName>Yahoo! Mail</displayName>
     <displayShortName>Yahoo</displayShortName>


### PR DESCRIPTION
Fixes [@aol.co.uk, @aol.de country domains get Yahoo config, should get AOL config](https://bugzilla.mozilla.org/show_bug.cgi?id=1668625).

Adds MX servers for AOL and Yahoo, and AOL country domains.