### PR TITLE
add SMTP SSL/TLS for t-online.de

### DIFF
--- a/ispdb/t-online.de
+++ b/ispdb/t-online.de
@@ -21,6 +21,13 @@
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>securesmtp.t-online.de</hostname>
+      <port>465</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </outgoingServer>
+    <outgoingServer type="smtp">
+      <hostname>securesmtp.t-online.de</hostname>
       <port>587</port>
       <socketType>STARTTLS</socketType>
       <username>%EMAILADDRESS%</username>


### PR DESCRIPTION
Related to: https://github.com/thundernest/autoconfig/issues/25

I added the SMTP SSL/TLS config for t-online.de after successfully testing it.

The official reference by T-Online.de / Telekom can be found here (in German):
[https://www.telekom.de/hilfe/festnetz-internet-tv/e-mail/e-mail-server-e-mail-protokolle-und-e-mail-einrichtung/posteingangsserver-und-postausgangsserver](https://www.telekom.de/hilfe/festnetz-internet-tv/e-mail/e-mail-server-e-mail-protokolle-und-e-mail-einrichtung/posteingangsserver-und-postausgangsserver)