### PR TITLE
Add schwaz.net autoconfig

### DIFF
--- a/ispdb/schwaz.net
+++ b/ispdb/schwaz.net
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <clientConfig version="1.1">
   <emailProvider id="schwaz.net">
-    <!-- domain hoster, per MX -->
     <domain>schwaz.net</domain>
     <displayName>schwaz.net | Stadtwerke Schwaz</displayName>
     <displayShortName>schwaz.net</displayShortName>

--- a/ispdb/schwaz.net
+++ b/ispdb/schwaz.net
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<clientConfig version="1.1">
+  <emailProvider id="schwaz.net">
+    <!-- domain hoster, per MX -->
+    <domain>schwaz.net</domain>
+    <displayName>schwaz.net | Stadtwerke Schwaz</displayName>
+    <displayShortName>schwaz.net</displayShortName>
+    <incomingServer type="imap">
+      <hostname>imap.schwaz.net</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="pop3">
+      <hostname>pop3.schwaz.net</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>mail.schwaz.net</hostname>
+      <port>465</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </outgoingServer>
+    <outgoingServer type="smtp">
+      <hostname>mail.schwaz.net</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </outgoingServer>
+    <documentation url="https://stadtwerkeschwaz.at/schwaz-net/anleitungen#Einstellungen">
+      <descr lang="en">Configuration for eMail programs</descr>
+      <descr lang="de">Einstellungen eMail-Programm</descr>
+    </documentation>
+  </emailProvider>
+  <webMail>
+    <loginPage url="https://webmail.schwaz.net/?login=" />
+    <loginPageInfo url="https://webmail.schwaz.net/?login=">
+      <username>%EMAILADDRESS%</username>
+      <usernameField id="username" />
+      <passwordField id="password" />
+      <loginButton name="submit" />
+    </loginPageInfo>
+  </webMail>
+</clientConfig>


### PR DESCRIPTION
This adds proper configuration for the local provider schwaz.net in lovely Tyrol, Austria. The automatically derived values so far yield a nonworking configuration, I haven't been able to figure out whether this is a misconfiguration of the provider at the DNS level or just insufficient guesses. The static client config corresponds to the officially documented (and tested) [settings](https://stadtwerkeschwaz.at/schwaz-net/anleitungen#Einstellungen), only preferring SSL over STARTTLS for SMTP against the provider's stated order of preference.