### PR TITLE
supporting POP/SMTP over SSL for Biglobe.ne.jp

### DIFF
--- a/ispdb/biglobe.ne.jp
+++ b/ispdb/biglobe.ne.jp
@@ -7,17 +7,17 @@
     <displayShortName>Biglobe</displayShortName>
     <incomingServer type="pop3">
       <hostname>mail.biglobe.ne.jp</hostname>
-      <port>110</port>
-      <socketType>plain</socketType>
+      <port>995</port>
+      <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>mail.biglobe.ne.jp</hostname>
-      <port>587</port>
-      <socketType>plain</socketType>
+      <port>465</port>
+      <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
-      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
     </outgoingServer>
   </emailProvider>
 </clientConfig>


### PR DESCRIPTION
SSL connection has been mandatory for the provider.