### PR TITLE
Create educa.madrid.org

### DIFF
--- a/ispdb/educa.madrid.org.xml
+++ b/ispdb/educa.madrid.org.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<clientConfig version="1.1">
+    <emailProvider id="educa.madrid.org">
+        <domain>educa.madrid.org</domain>
+
+        <displayname>Plataforma EducaMadrid</displayname>
+        <displayShortName>EducaMadrid</displayShortName>
+
+        <incomingServer type="imap">
+            <hostname>imap.educa.madrid.org</hostname>
+            <port>993</port>
+            <socketType>SSL</socketType>
+            <authentication>password-cleartext</authentication>
+            <username>%EMAILLOCALPART%</username>
+        </incomingServer>
+        <incomingServer type="pop3">
+            <hostname>pop.educa.madrid.org</hostname>
+            <port>995</port>
+            <socketType>SSL</socketType>
+            <authentication>password-cleartext</authentication>
+            <username>%EMAILLOCALPART%</username>
+        </incomingServer>
+        <outgoingServer type="smtp">
+            <hostname>smtp01.educa.madrid.org</hostname>
+            <port>587</port>
+            <socketType>STARTTLS</socketType>
+            <authentication>password-cleartext</authentication>
+            <username>%EMAILLOCALPART%</username>
+        </outgoingServer>
+        <outgoingServer type="smtp">
+            <hostname>smtp01.educa.madrid.org</hostname>
+            <port>465</port>
+            <socketType>SSL</socketType>
+            <authentication>password-cleartext</authentication>
+            <username>%EMAILLOCALPART%</username>
+        </outgoingServer>
+        <documentation url="https://documentacion.educa.madrid.org/books/correo/page/clientes-de-correo"/>
+    </emailProvider>
+    <webMail>
+        <loginPage url="https://correoweb.educa.madrid.org/"/>
+        <loginPageInfo url="https://correoweb.educa.madrid.org/">
+            <username>%EMAILLOCALPART%</username>
+            <usernameField id="rcmloginuser" name="_user"/>
+            <passwordField id="rcmloginpwd" name="_pass"/>
+            <loginButton id="rcmloginsubmit"/>
+        </loginPageInfo>
+    </webMail>
+</clientConfig>

--- a/ispdb/educa.madrid.org.xml
+++ b/ispdb/educa.madrid.org.xml
@@ -22,15 +22,15 @@
         </incomingServer>
         <outgoingServer type="smtp">
             <hostname>smtp01.educa.madrid.org</hostname>
-            <port>587</port>
-            <socketType>STARTTLS</socketType>
+            <port>465</port>
+            <socketType>SSL</socketType>
             <authentication>password-cleartext</authentication>
             <username>%EMAILLOCALPART%</username>
         </outgoingServer>
         <outgoingServer type="smtp">
             <hostname>smtp01.educa.madrid.org</hostname>
-            <port>465</port>
-            <socketType>SSL</socketType>
+            <port>587</port>
+            <socketType>STARTTLS</socketType>
             <authentication>password-cleartext</authentication>
             <username>%EMAILLOCALPART%</username>
         </outgoingServer>


### PR DESCRIPTION
educa.madrid.org is the domain used for all email communications of the public school sector of Madrid's region (not including universities). It has over 1.5 million users which include all students in public schools in the region of Madrid.

I've tested the file locally and it seems to work just fine. The source used to look up the correct configuration is [here](https://documentacion.educa.madrid.org/books/correo/page/clientes-de-correo), although it's written in Spanish.