### PR TITLE
Remove unused file

### DIFF
--- a/ispdb/cloudnine-net.jp
+++ b/ispdb/cloudnine-net.jp
@@ -1,5 +1,0 @@
-<clientConfig version="1.1">
-  <emailProvider id="cloudnine-net.jp">
-    <domain>cloudnine-net.jp</domain>
-  </emailProvider>
-</clientConfig>


### PR DESCRIPTION
The "empty" file was added to work around problems when trying to get rid of a previously valid config on the production server. Nowadays the deployment script replaces whole directories and thus correctly gets rid of previously used configs.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1223709

In a fun twist, this lead to the deployment script [update.sh](https://github.com/thundernest/thundernest-ansible/blob/ba8d35e68415b3d4a05943b9d2ff649d9f92362f/files/update.sh#L19) including a work-around to avoid an error when converting configs to version 1.0.

The pull request to clean up the deployment script after this has been merged: https://github.com/thundernest/thundernest-ansible/pull/31