### PR TITLE
 Add GitHub workflow to validate file extensions

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -1,0 +1,15 @@
+name: Validate client config
+
+on: [pull_request]
+
+jobs:
+  validate_config:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Validate file extensions
+      run: | 
+       set -o pipefail
+       ls -1 ispdb/ | grep -v '\.xml$' | awk '{print "::error file=ispdb/"$0"::File name \"ispdb/"$0"\" does not end in .xml – Please rename!"}' && exit 1 || true


### PR DESCRIPTION
This adds a GitHub workflow to validate file extensions on pull requests. The check can be seen in action here:
- https://github.com/cketti/autoconfig/pull/2
- https://github.com/cketti/autoconfig/pull/3

The error message is added as an annotation to the file with the wrong extension. See https://github.com/cketti/autoconfig/pull/2/files