### PR TITLE
free.fr: Use SSL for SMTP

### DIFF
--- a/ispdb/free.fr.xml
+++ b/ispdb/free.fr.xml
@@ -2,8 +2,8 @@
 <clientConfig version="1.1">
   <emailProvider id="free.fr">
     <domain>free.fr</domain>
-    <displayName>Free Telecom</displayName>
-    <displayShortName>free.fr</displayShortName>
+    <displayName>Freebox</displayName>
+    <displayShortName>Freebox</displayShortName>
 
     <incomingServer type="imap">
       <hostname>imap.free.fr</hostname>
@@ -23,40 +23,26 @@
 
     <outgoingServer type="smtp">
       <hostname>smtp.free.fr</hostname>
-      <port>25</port>
-      <socketType>plain</socketType>
+      <port>465</port>
+      <socketType>SSL</socketType>
       <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
-      <restriction>client-IP-address</restriction>
     </outgoingServer>
-    <!-- The following config also exists, but
-         - the user needs to manually enable
-           "SMTP auth" in their admin webpages, as noted below.
-         - Free says this is not supposed to be used
-           inside the Free network, because checking the password is
-           unnecessary in that case and uses "unnecessary CPU resources".
-         This means that users can't move outside home
-         with the default config. :-( See bug 556750.
-    <outgoingServer type="smtp">
-      <hostname>smtp.free.fr</hostname>
-      <port>587</port>
-      <socketType>plain</socketType>
-      <username>%EMAILLOCALPART%</username>
-      <authentication>password-encrypted</authentication>
-    </outgoingServer>
-    -->
 
-    <documentation url="http://www.free.fr/assistance/599-thunderbird.html">
+    <documentation url="https://assistance.free.fr/articles/configurer-de-maniere-avancee-mon-logiciel-de-messagerie-609">
       <descr lang="en">How to set up Thunderbird with Free.fr</descr>
       <descr lang="fr">Configurer Thunderbird avec Free</descr>
     </documentation>
-    <documentation url="http://www.free.fr/assistance/2514-interet-et-fonctionnement.html">
-      <descr lang="en">How to setup a secure IMAP account</descr>
-      <descr lang="fr">Serveur de réception IMAP sécurisé SSL</descr>
-    </documentation>
-    <documentation url="http://www.free.fr/assistance/2407-interet-et-fonctionnement.html">
-      <descr lang="en">How to enable authenticated SMTP</descr>
-      <descr lang="fr">Comment activer le serveur d'envoi SMTP authentifié</descr>
-    </documentation>
   </emailProvider>
+
+  <webMail>
+    <loginPage url="https://webmail.free.fr" />
+    <loginPageInfo url="https://webmail.free.fr">
+      <username>%EMAILADDRESS%</username>
+      <usernameField id="imapuser" />
+      <passwordField id="passwd" />
+      <loginButton id="rcmloginsubmit" />
+    </loginPageInfo>
+  </webMail>
 </clientConfig>
+


### PR DESCRIPTION
Previously:
* In the past, the large French ISP free.fr (about 30% market share) didn't have an SMTP server that works everywhere, both in their network and outside. So, users needed 2 slightly different configurations for when they are at home and when they are elsewhere. No config would work in both places.
* Additionally, free didn't allow SSL for SMTP, considering it unnecessary.

Changes:
* Luckily, they now allow an SSL config for SMTP. This PR updates our config file to this improvement.
* The documentation URL has changed
* I've also added the webmail config, just for those clients who need it.