### PR TITLE
Update settings for mnet.ne.jp

### DIFF
--- a/ispdb/mnet.ne.jp.xml
+++ b/ispdb/mnet.ne.jp.xml
@@ -4,19 +4,45 @@
     <domain>mnet.ne.jp</domain>
     <displayName>Mnet メール サービス</displayName>
     <displayShortName>Mnetメール</displayShortName>
+    <incomingServer type="imap">
+      <hostname>mail.mnet.ne.jp</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="imap">
+      <hostname>mail.mnet.ne.jp</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="pop3">
+      <hostname>mail.mnet.ne.jp</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
     <incomingServer type="pop3">
       <hostname>mail.mnet.ne.jp</hostname>
       <port>110</port>
-      <socketType>plain</socketType>
+      <socketType>STARTTLS</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>mail.mnet.ne.jp</hostname>
       <port>587</port>
-      <socketType>plain</socketType>
+      <socketType>STARTTLS</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
     </outgoingServer>
   </emailProvider>
 </clientConfig>


### PR DESCRIPTION
I wasn't able to find a web page under the domain mnet.ne.jp listing these server settings. However, various third-party email clients use these. And I manually verified that IMAP/POP/SMTP servers are reachable using these settings.