### PR TITLE
Remove UTF-8 BOM

### DIFF
--- a/ispdb/charter.com.xml
+++ b/ispdb/charter.com.xml
@@ -1,4 +1,4 @@
-﻿<clientConfig version="1.1">
+<clientConfig version="1.1">
   <emailProvider id="charter.com">
     <domain>charter.net</domain>
     <domain>charter.com</domain>


### PR DESCRIPTION
The file started with the 3 bytes `EF BB BF`, the UTF-8 representation of the [BOM](https://en.wikipedia.org/wiki/Byte_order_mark). This is unnecessary. And the XML parser we're using on Android throws an exception when trying to read the file.