### PR TITLE
jet.ne.jp: Fix 'socketType' value

### DIFF
--- a/ispdb/jet.ne.jp.xml
+++ b/ispdb/jet.ne.jp.xml
@@ -28,7 +28,7 @@
     <outgoingServer type="smtp">
       <hostname>smtp.jet.ne.jp</hostname>
       <port>587</port>
-      <socketType>STARTSSL</socketType>
+      <socketType>STARTTLS</socketType>
       <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>


### PR DESCRIPTION
In PR #57 I accidentally set the `socketType` value to `STARTSSL` instead of `STARTTLS`.