### PR TITLE
Update settings for iCloud Mail

### DIFF
--- a/ispdb/me.com.xml
+++ b/ispdb/me.com.xml
@@ -10,23 +10,15 @@
       <port>993</port>
       <socketType>SSL</socketType>
       <username>%EMAILLOCALPART%</username>
-      <authentication>plain</authentication>
-    </incomingServer>
-    <!-- Not working for me. BenB 2010-08-19 from Europe
-    <outgoingServer type="smtp">
-      <hostname>smtp.me.com</hostname>
-      <port>465</port>
-      <socketType>SSL</socketType>
-      <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
-    </outgoingServer>
-    -->
+    </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.mail.me.com</hostname>
       <port>587</port>
       <socketType>STARTTLS</socketType>
-      <username>%EMAILLOCALPART%</username>
-      <authentication>plain</authentication>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
     </outgoingServer>
+    <documentation url="https://support.apple.com/HT202304"/>
   </emailProvider>
 </clientConfig>


### PR DESCRIPTION
- Replaced deprecated `authentication` value of `plain` with `password-cleartext` (outgoing server).
- Removed commented-out, non-working `outgoingServer` entry.
- For the outgoing server, changed `username` value from `%EMAILLOCALPART%` to `%EMAILADDRESS%` because that's what the provider's documentation says. I've verified with an `@icloud.com` account that this works.
- Added documentation tag.