### PR TITLE
Update settings for Charter

### DIFF
--- a/ispdb/charter.com.xml
+++ b/ispdb/charter.com.xml
@@ -1,8 +1,9 @@
 <clientConfig version="1.1">
   <emailProvider id="charter.com">
     <domain>charter.net</domain>
-    <domain>charter.com</domain>
-    <displayName>Charter Commuications</displayName>
+    <domain>spectrum.net</domain>
+    <domain>bresnan.net</domain>
+    <displayName>Charter Communications</displayName>
     <displayShortName>Charter</displayShortName>
     <incomingServer type="imap">
       <hostname>mobile.charter.net</hostname>
@@ -11,23 +12,13 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <incomingServer type="imap">
-      <hostname>imap.charter.net</hostname>
-      <port>143</port>
-      <socketType>plain</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-    </incomingServer>
-    <!-- We can't in good conscience recommend an insecure config while a secure config is available.
     <incomingServer type="pop3">
-      <hostname>pop.charter.net</hostname>
-      <port>110</port>
-      <socketType>plain</socketType>
+      <hostname>mobile.charter.net</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    -->
-
     <outgoingServer type="smtp">
       <hostname>mobile.charter.net</hostname>
       <!-- Yes, they have SSL (not STARTTLS, not plain SMTP) on port 587. Spec violation. -->
@@ -36,17 +27,8 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <outgoingServer type="smtp">
-      <hostname>smtp.charter.net</hostname>
-      <port>25</port>
-      <socketType>plain</socketType>
-      <username>%EMAILADDRESS%</username>
-      <authentication>password-cleartext</authentication>
-      <restriction>client-IP-address</restriction>
-    </outgoingServer>
-    <documentation url="http://www.myaccount.charter.com/customers/support.aspx?supportarticleid=1417">
-      <descr>POP/IMAP and SMTP settings for Charter, including mobile</descr>
+    <documentation url="https://www.spectrum.net/support/internet/mobile-email-setup">
+      <descr>Spectrum Email Server Settings</descr>
     </documentation>
-
   </emailProvider>
 </clientConfig>

--- a/ispdb/charter.net.xml
+++ b/ispdb/charter.net.xml
@@ -1,5 +1,5 @@
 <clientConfig version="1.1">
-  <emailProvider id="charter.com">
+  <emailProvider id="charter.net">
     <domain>charter.net</domain>
     <domain>spectrum.net</domain>
     <domain>bresnan.net</domain>


### PR DESCRIPTION
- Removes entries with `<socketType>plain</socketType>`.
- Adds POP3 settings.
- Adds the domains `spectrum.net` and `bresnan.net` that use the same mail server settings.

https://www.spectrum.net/support/internet/mobile-email-setup