### PR TITLE
Add Yahoo export IMAP server

### DIFF
--- a/ispdb/yahoo.com.xml
+++ b/ispdb/yahoo.com.xml
@@ -32,6 +32,14 @@
       <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
     </incomingServer>
+    <incomingServer type="imap">
+      <hostname>export.imap.mail.yahoo.com</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
     <incomingServer type="pop3">
       <hostname>pop.mail.yahoo.com</hostname>
       <port>995</port>


### PR DESCRIPTION
Yahoo has an "export" IMAP server endpoint that allows to download more than 10k messages, but is read-only. https://help.yahoo.com/kb/download-email-yahoo-mail-third-party-sln28681.html

This is provided as a "Takeout" feature (when you go to https://mail.yahoo.com/getmydata, it links to the help document above), so it will probably only get used by people changing the server address manually.

Adding it here allows this endpoint to use the OAuth login method.