### PR TITLE
Add ISPDB config for tmmd.club under ispdb/tmmd.club.xml (IMAP/POP3/SMTP, TLS only)

### DIFF
--- a/ispdb/tmmd.club.xml
+++ b/ispdb/tmmd.club.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<clientConfig version="1.1">
+  <emailProvider id="tmmd.club">
+    <domain>tmmd.club</domain>
+
+    <displayName>Tony's Misty Man Den Mail</displayName>
+    <displayShortName>TMMD Mail</displayShortName>
+
+    <!-- IMAP -->
+    <incomingServer type="imap">
+      <hostname>mx.tmmd.club</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+
+    <!-- POP3 -->
+    <incomingServer type="pop3">
+      <hostname>mx.tmmd.club</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+
+    <!-- SMTP -->
+    <outgoingServer type="smtp">
+      <hostname>mx.tmmd.club</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+  </emailProvider>
+</clientConfig>


### PR DESCRIPTION
### Domain
- tmmd.club

### Email servers
- incoming (IMAP/POP3) and outgoing (SMTP): mx.tmmd.club

### Ports and Security
- IMAP: 993 (SSL/TLS)
- POP3: 995 (SSL/TLS)
- SMTP: 587 (STARTTLS)

unencrypted connections are not supported (ports 110/143/25/465 are closed)

### Authentication
- username: full email address
- authentication method: password-cleartext

### Verification
- tested successfully with Thunderbird using self-hosted autoconfig (autoconfig.tmmd.club) which is functionally identical to this file
- tested TLS certificates: valid and trusted for mx.tmmd.club