### PR TITLE
Add att.net Oauth2 auth option

### DIFF
--- a/ispdb/att.net.xml
+++ b/ispdb/att.net.xml
@@ -18,6 +18,7 @@
       <port>993</port>
       <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
     </incomingServer>
     <incomingServer type="pop3">
@@ -25,6 +26,7 @@
       <port>995</port>
       <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
     </incomingServer>
     <outgoingServer type="smtp">
@@ -32,6 +34,7 @@
       <port>465</port>
       <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
     <documentation url="https://www.att.com/support/article/email-support/KM1010523/">


### PR DESCRIPTION
While Thunderbird doesn't yet have this enabled in Oauth2Providers.sys.mjs, there is a guard in place that will only present this as an authentication option for builds which have supporting configurations.

The plan is to add att.net support within Thunderbird to point at login.yahoo.com