### PR TITLE
Update messagingengine.com to use OAuth2

### DIFF
--- a/ispdb/messagingengine.com.xml
+++ b/ispdb/messagingengine.com.xml
@@ -2,12 +2,13 @@
 <clientConfig version="1.1">
   <emailProvider id="MessagingEngine">
     <domain>messagingengine.com</domain>
-    <displayName>FastMail</displayName>
-    <displayShortName>FastMail</displayShortName>
+    <displayName>Fastmail</displayName>
+    <displayShortName>Fastmail</displayShortName>
     <incomingServer type="imap">
       <hostname>imap.fastmail.com</hostname>
       <port>993</port>
       <socketType>SSL</socketType>
+      <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </incomingServer>
@@ -15,6 +16,7 @@
       <hostname>pop.fastmail.com</hostname>
       <port>995</port>
       <socketType>SSL</socketType>
+      <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </incomingServer>
@@ -22,6 +24,7 @@
       <hostname>smtp.fastmail.com</hostname>
       <port>465</port>
       <socketType>SSL</socketType>
+      <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </outgoingServer>
@@ -29,7 +32,10 @@
       <descr lang="en">Server Names and Ports</descr>
     </instruction>
     <instruction url="https://www.fastmail.com/help/clients/thunderbird.html">
-      <descr lang="en">Using FastMail with Mozilla Thunderbird</descr>
+      <descr lang="en">Using Fastmail with Mozilla Thunderbird</descr>
     </instruction>
   </emailProvider>
+  <webMail>
+    <loginPage url="https://app.fastmail.com/login/?domain=%EMAILDOMAIN%" />
+  </webMail>
 </clientConfig>


### PR DESCRIPTION
Support for Fastmail OAuth authentication was added in Thunderbird 115 (https://bugzilla.mozilla.org/show_bug.cgi?id=1785240).

Most Fastmail users have their domains setup so that autoconfig.${domain} points to our servers and delivers the correct autoconfig setup so OAuth just works.

However for users that don't have that setup, Thunderbird eventually falls back to the MX record lookup for the domain and finally the ISPDB lookup for messagingengine.com. Unfortunately that entry is outdated and still lists authentication as `password-cleartext`.

This causes Thunderbird to get confused because it displays a standard "password" entry box for connecting to the IMAP server, but also simultaneously initiates the OAuth authentication flow, I presume for calendar/contacts access.

This updates the ISBDB entry to list OAuth2 as the correct authentication mechanism for messagingengine.com