### PR TITLE
Add support for other data centers of zoho mail

### DIFF
--- a/ispdb/zoho.com.au.xml
+++ b/ispdb/zoho.com.au.xml
@@ -5,6 +5,8 @@
     <domain>zohomail.com.au</domain>
     <displayName>Zoho Mail - Australia</displayName>
     <displayShortName>Zoho - Australia</displayShortName>
+    <!-- You must enable IMAP Access for your account  
+	     before you begin the configuration in the email client.  --> 
     <incomingServer type="imap">
       <hostname>imap.zoho.com.au</hostname>
       <port>993</port>
@@ -12,7 +14,7 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable IMAP Access for your account  
+    <!-- You must enable POP Access for your account  
 	     before you begin the configuration in the email client.  -->
     <incomingServer type="pop3">
       <hostname>pop.zoho.com.au</hostname>
@@ -21,8 +23,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable POP Access for your account  
-	     before you begin the configuration in the email client.  -->
     <outgoingServer type="smtp">
       <hostname>smtp.zoho.com.au</hostname>
       <port>465</port>

--- a/ispdb/zoho.com.xml
+++ b/ispdb/zoho.com.xml
@@ -5,6 +5,8 @@
     <domain>zohomail.com</domain>
     <displayName>Zoho Mail - US</displayName>
     <displayShortName>Zoho - US</displayShortName>
+    <!-- You must enable IMAP Access for your account  
+	     before you begin the configuration in the email client.  -->
     <incomingServer type="imap">
       <hostname>imap.zoho.com</hostname>
       <port>993</port>
@@ -12,7 +14,7 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable IMAP Access for your account  
+    <!-- You must enable POP Access for your account  
 	     before you begin the configuration in the email client.  -->
     <incomingServer type="pop3">
       <hostname>pop.zoho.com</hostname>
@@ -21,8 +23,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable POP Access for your account  
-	     before you begin the configuration in the email client.  -->
     <outgoingServer type="smtp">
       <hostname>smtp.zoho.com</hostname>
       <port>465</port>

--- a/ispdb/zoho.eu.xml
+++ b/ispdb/zoho.eu.xml
@@ -5,6 +5,8 @@
     <domain>zohomail.eu</domain>
     <displayName>Zoho Mail - Europe</displayName>
     <displayShortName>Zoho - Europe</displayShortName>
+    <!-- You must enable IMAP Access for your account  
+	     before you begin the configuration in the email client.  -->
     <incomingServer type="imap">
       <hostname>imap.zoho.eu</hostname>
       <port>993</port>
@@ -12,7 +14,7 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable IMAP Access for your account  
+    <!-- You must enable POP Access for your account  
 	     before you begin the configuration in the email client.  -->
     <incomingServer type="pop3">
       <hostname>pop.zoho.eu</hostname>
@@ -21,8 +23,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable POP Access for your account  
-	     before you begin the configuration in the email client.  -->
     <outgoingServer type="smtp">
       <hostname>smtp.zoho.eu</hostname>
       <port>465</port>

--- a/ispdb/zoho.in.xml
+++ b/ispdb/zoho.in.xml
@@ -5,6 +5,8 @@
     <domain>zohomail.in</domain>
     <displayName>Zoho Mail - India</displayName>
     <displayShortName>Zoho - India</displayShortName>
+    <!-- You must enable IMAP Access for your account  
+	     before you begin the configuration in the email client.  -->
     <incomingServer type="imap">
       <hostname>imap.zoho.in</hostname>
       <port>993</port>
@@ -12,7 +14,7 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable IMAP Access for your account  
+    <!-- You must enable POP Access for your account  
 	     before you begin the configuration in the email client.  -->
     <incomingServer type="pop3">
       <hostname>pop.zoho.in</hostname>
@@ -21,8 +23,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable POP Access for your account  
-	     before you begin the configuration in the email client.  -->
     <outgoingServer type="smtp">
       <hostname>smtp.zoho.in</hostname>
       <port>465</port>

--- a/ispdb/zoho.jp.xml
+++ b/ispdb/zoho.jp.xml
@@ -5,6 +5,8 @@
     <domain>zohomail.jp</domain>
     <displayName>Zoho Mail - Japan</displayName>
     <displayShortName>Zoho - Japan</displayShortName>
+    <!-- You must enable IMAP Access for your account  
+	     before you begin the configuration in the email client.  -->
     <incomingServer type="imap">
       <hostname>imap.zoho.jp</hostname>
       <port>993</port>
@@ -21,8 +23,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable POP Access for your account  
-	     before you begin the configuration in the email client.  -->
     <outgoingServer type="smtp">
       <hostname>smtp.zoho.jp</hostname>
       <port>465</port>

--- a/ispdb/zohocloud.ca.xml
+++ b/ispdb/zohocloud.ca.xml
@@ -5,6 +5,8 @@
     <domain>zohomailcloud.ca</domain>
     <displayName>Zoho Mail - Canada</displayName>
     <displayShortName>Zoho - Canada</displayShortName>
+    <!-- You must enable IMAP Access for your account  
+	     before you begin the configuration in the email client.  -->
     <incomingServer type="imap">
       <hostname>imap.zohocloud.ca</hostname>
       <port>993</port>
@@ -12,7 +14,7 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable IMAP Access for your account  
+    <!-- You must enable POP Access for your account  
 	     before you begin the configuration in the email client.  -->
     <incomingServer type="pop3">
       <hostname>pop.zohocloud.ca</hostname>
@@ -21,8 +23,6 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
-    <!-- You must enable POP Access for your account  
-	     before you begin the configuration in the email client.  -->
     <outgoingServer type="smtp">
       <hostname>smtp.zohocloud.ca</hostname>
       <port>465</port>


### PR DESCRIPTION
Zoho Mail has data centers in US, EU, India, Australia, Japan, Canada and Saudi Arabia. This PR adds support for all except Saudi Arabia. I was unable to get the correct setting for Saudi Arabia, and will handle it in a separate PR if I manage to get it working.

Each data center has its own domain, mx records and even own smtp, imap and pop3 servers.