### PR TITLE
Add `graph` incoming server type for Office365.

### DIFF
--- a/ispdb/office365.com.xml
+++ b/ispdb/office365.com.xml
@@ -35,6 +35,11 @@
       <ewsURL>https://outlook.office365.com/ews/exchange.asmx</ewsURL>
       <useGlobalPreferredServer>true</useGlobalPreferredServer>
     </incomingServer>
+    <incomingServer type="graph">
+      <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
+      <url>https://graph.microsoft.com</url>
+    </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.office365.com</hostname>
       <port>587</port>


### PR DESCRIPTION
This adds a `graph` configuration for the Office365 domains to provide a configuration for Graph API.

This follows the [draft RFC](https://www.ietf.org/archive/id/draft-ietf-mailmaint-autoconfig-03.html#name-type) for mail autoconfig submitted to the mailmaint working group.