### PR TITLE
Add configuration for inter-corporate.com eMail provider

### DIFF
--- a/ispdb/inter-corporate.com.xml
+++ b/ispdb/inter-corporate.com.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<clientConfig version="1.1">
+  <emailProvider id="inter-corporate.com">
+    <domain>inter-corporate.com</domain>
+    <domain>inter-corporate.net</domain>
+    <domain>inter-corporate.org</domain>
+    <domain>inter-corporate.ca</domain>
+    <domain>8x.ca</domain>
+    <domain>bcmail.ca</domain>
+    <domain>canadianemail.ca</domain>
+    <domain>commodore64.ca</domain>
+    <domain>c64mail.com</domain>
+    <domain>lmail.ca</domain>
+    <domain>modperl.pl</domain>
+    <domain>pocomo.ca</domain>
+    <domain>pithball.com</domain>
+    <domain>pithballs.com</domain>
+    <domain>sexmail.ca</domain>
+    <domain>sexymail.ca</domain>
+    <domain>ugfzc3dvcmq6.com</domain>
+    <domain>wancity.com</domain>
+    <domain>wordpressmail.ca</domain>
+    <domain>wpmail.ca</domain>
+    <domain>yvrtaxi.ca</domain>
+    <domain>yvrtaxi.com</domain>
+    <domain>xn--pssq86a.com</domain>
+    <displayName>Inter-Corporate eMail 🇨🇦</displayName>
+    <displayShortName>eMail</displayShortName>
+    <incomingServer type="imap">
+      <hostname>mail.inter-corporate.com</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <incomingServer type="imap">
+      <hostname>mail.inter-corporate.com</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>mail.inter-corporate.com</hostname>
+      <port>465</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </outgoingServer>
+    <outgoingServer type="smtp">
+      <hostname>mail.inter-corporate.com</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </outgoingServer>
+    <documentation url="https://www.inter-corporate.com/mail/%EMAILADDRESS%">
+      <descr lang="en">Electronic Mail Configuration</descr>
+    </documentation>
+  </emailProvider>
+  <webMail>
+    <loginPage url="https://mail.inter-corporate.com/" />
+  </webMail>
+</clientConfig>


### PR DESCRIPTION
A major internet provider is intermittently blocking IPv6 connections, which prevents automatic configuration in Mozilla Thunderbird, Evolution, etc., for more of our clients now that Linux is gaining popularity.  We're hoping that inclusion in ISPDB will resolve this problem more easily than wasting any more time in trying to convince the internet provider's technical support to fix their IPv6 issues (we rejected their recommendation to drop IPv6 support).

Thank you.