### PR TITLE
Add autoconfig for seguromail.com.br

### DIFF
--- a/ispdb/seguromail.com.br.xml
+++ b/ispdb/seguromail.com.br.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<clientConfig version="1.1">
+  <emailProvider id="seguromail.com.br">
+    <!--
+      Dominios diretos do provedor.
+      Dominios dos clientes NAO precisam ser listados aqui —
+      o Thunderbird faz lookup pelo MX record, e se o MX
+      apontar para seguromail.com.br, ele usa esta config.
+    -->
+    <domain>seguromail.com.br</domain>
+
+    <displayName>SeguroMail</displayName>
+    <displayShortName>SeguroMail</displayShortName>
+
+    <incomingServer type="imap">
+      <hostname>imap.seguromail.com.br</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+
+    <incomingServer type="imap">
+      <hostname>imap.seguromail.com.br</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+
+    <incomingServer type="pop3">
+      <hostname>pop3.seguromail.com.br</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+
+    <outgoingServer type="smtp">
+      <hostname>smtp.seguromail.com.br</hostname>
+      <port>465</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+
+    <outgoingServer type="smtp">
+      <hostname>smtp.seguromail.com.br</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+
+  </emailProvider>
+</clientConfig>

--- a/ispdb/seguromail.com.br.xml
+++ b/ispdb/seguromail.com.br.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <clientConfig version="1.1">
   <emailProvider id="seguromail.com.br">
-    <!--
-      Dominios diretos do provedor.
-      Dominios dos clientes NAO precisam ser listados aqui —
-      o Thunderbird faz lookup pelo MX record, e se o MX
-      apontar para seguromail.com.br, ele usa esta config.
-    -->
     <domain>seguromail.com.br</domain>
 
     <displayName>SeguroMail</displayName>


### PR DESCRIPTION
  Adding autoconfig for seguromail.com.br, a Brazilian email hosting
  provider. Supports IMAP/SSL (993), POP3/SSL (995), SMTP/SSL (465).
  Username format is full email address.