### PR TITLE
Add POP3 config for daum.net, fix SMTP auth method

### DIFF
--- a/ispdb/daum.net.xml
+++ b/ispdb/daum.net.xml
@@ -11,12 +11,19 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
+    <incomingServer type="pop3">
+      <hostname>pop.daum.net</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.daum.net</hostname>
       <port>465</port>
       <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
-      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
     </outgoingServer>
     <documentation url="https://cs.daum.net/faq/43/9234.html#24081"/>
   </emailProvider>


### PR DESCRIPTION
daum.net supports POP3 (pop.daum.net:995, SSL) but only IMAP was listed.

SMTP was set to password-encrypted, but smtp.daum.net only advertises
AUTH LOGIN PLAIN, so password-cleartext is the correct value.